### PR TITLE
Sets EOF if getBuffer is nullptr

### DIFF
--- a/source/extensions/common/http_wasm/exports.cc
+++ b/source/extensions/common/http_wasm/exports.cc
@@ -203,7 +203,9 @@ int64_t read_body(Word kind, Word val, Word size) {
   auto* context = contextOrEffectiveContext();
   auto* buffer = context->getBuffer(static_cast<WasmBufferType>(kind.u64_));
   if (buffer == nullptr) {
-    return 0;
+    uint64_t eof = 1;
+    eof = (eof << 32);
+    return eof;
   }
   auto targetMemory = context->runtime()->getMemory(val.u64_, size);
   if (!targetMemory) {

--- a/source/extensions/common/http_wasm/exports.cc
+++ b/source/extensions/common/http_wasm/exports.cc
@@ -44,8 +44,10 @@ Word log_enabled(Word log_level) {
   return context->runtime()->cmpLogLevel(static_cast<LogLevel>(log_level.u64_));
 }
 
+uint32_t httpWasmLogLevelDebug = 0xFFFFFFFF; // http-wasm log level for debug is -1;
+
 void log(Word level, Word address, Word size) {
-  if (level >= static_cast<uint64_t>(LogLevel::Max)) { // Max is none logs
+  if (level != static_cast<uint32_t>(httpWasmLogLevelDebug) && level >= static_cast<uint64_t>(LogLevel::Max)) { // Max is none logs
     return;
   }
   auto* context = contextOrEffectiveContext();


### PR DESCRIPTION
Hey! Writing down here the results of debugging an endless loop found while running some tests against `coraza-http-wasm`. 

Envoy enters in the endless loop when the response body returned by the backend is empty. For example, using http-bin as a backend it happens with a request like:
```
curl -XGET http://localhost:8081/status/200
```

Extracting the code from Coraza, a small `handleResponse` that triggers the bug is:
```
type readWriterTo struct {
	api.Body
}

func (sr readWriterTo) Read(p []byte) (n int, err error) {
	size, eof := sr.Body.Read(p)
	if eof {
		err = io.EOF
	}
	n = int(size)
	return
}

// WriteTo implements io.WriterTo and it is handy for copying the body to the
// into the transaction buffer.
func (sr readWriterTo) WriteTo(w io.Writer) (n int64, err error) {
	size, err := sr.Body.WriteTo(w)
	return int64(size), err
}

var _ io.Reader = readWriterTo{}
var _ io.WriterTo = readWriterTo{}

func handleResponse(reqCtx uint32, _ api.Request, resp api.Response, _ bool) {
    var dest strings.Builder
    _, err := io.CopyN(&dest, readWriterTo{resp.Body()}, 100)
}
```

What happens is that the CopyN ends up in an endless loop made of infinite calls to `http_handler.read_body`. Envoy logs are:
```
[debug][wasm] [source/extensions/common/http_wasm/vm_runtime.cc:34] [vm<-host] http_handler.read_body return: 0
[debug][wasm] [source/extensions/common/http_wasm/vm_runtime.cc:34] [vm->host] http_handler.read_body(1, 103378448, 32768)
[debug][wasm] [source/extensions/common/http_wasm/vm_runtime.cc:34] [vm<-host] http_handler.read_body return: 0
[debug][wasm] [source/extensions/common/http_wasm/vm_runtime.cc:34] [vm->host] http_handler.read_body(1, 103378448, 32768)
[debug][wasm] [source/extensions/common/http_wasm/vm_runtime.cc:34] [vm<-host] http_handler.read_body return: 0
```

The read body call comes from a loop inside `copyBuffer`  (`io.go`) that internally calls`(b wasmBody) Read` in `http-wasm-fuest-tinygo` up until EOF or when reaching the number of expected bytes:
```
func read(b wasmBody, ptr uint32, limit imports.BufLimit) (size uint32, eof bool) {
	eofLen := imports.ReadBody(imports.BodyKind(b), ptr, limit)
	eof = (eofLen >> 32) == 1
	size = uint32(eofLen)
	return
} 
```
Here seems that eof is not detected if the buffer is empty. The host code called should be the following:
```
// Body ABIs...
int64_t read_body(Word kind, Word val, Word size) {
  if (kind > static_cast<uint64_t>(WasmBufferType::MAX)) {
    return 0;
  }
  auto* context = contextOrEffectiveContext();
  auto* buffer = context->getBuffer(static_cast<WasmBufferType>(kind.u64_));
  if (buffer == nullptr) {
    return 0;
  }
  . . .
```
Here, if the pointer to the buffer is null, return 0 is returned, and therefore the outer loop keeps looping expecting that it is still possible to read something from it.


I built a dummy wasm that basically has only the handleResponse written above and it works fine in an e2e run under http-wasm-guest-tinygo (Wazero), while it loops as described in envoy-http-wasm.

Not sure that the proposed fix is the right one, but wanted to share it because seems working pretty okay. Thanks!